### PR TITLE
feat: 회원 탈퇴 시 비밀번호 확인 기능 추가

### DIFF
--- a/controller/Cprofile.js
+++ b/controller/Cprofile.js
@@ -221,6 +221,43 @@ exports.patchUser = async (req, res) => {
   }
 };
 
+// 회원 탈퇴할 때 비밀번호 체크 위한 로직
+exports.checkPassword = async (req, res) => {
+  try {
+    const { password } = req.body;
+    const uId = req.session.user;
+
+    const user = await User.findOne({
+      where: { uId },
+    });
+
+    if (!user) {
+      // 사용자가 존재하지 않는 경우
+      res
+        .status(400)
+        .json({ success: false, message: '사용자가 존재하지 않습니다.' });
+      return;
+    }
+
+    // 비밀번호 일치 여부 확인
+    const passwordMatch = await bcrypt.compare(password, user.pw);
+
+    if (!passwordMatch) {
+      // 비밀번호가 일치하지 않는 경우
+      res
+        .status(401)
+        .json({ success: false, message: '비밀번호가 일치하지 않습니다.' });
+      return;
+    }
+
+    // 비밀번호가 일치하는 경우
+    res.status(200).json({ success: true, message: '비밀번호가 일치합니다.' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, message: '서버 오류 발생' });
+  }
+};
+
 // 회원 삭제 - 회원 탈퇴할 경우
 // /users/deleteprofile
 exports.deleteUser = async (req, res) => {

--- a/controller/Cprofile.js
+++ b/controller/Cprofile.js
@@ -45,7 +45,7 @@ exports.getUser = async (req, res) => {
       const comments = await Comment.findAll({ where: { uId } });
 
       // 사용자 정보를 마이페이지 템플릿에 전달하여 렌더링합니다.
-      res.render('profile', {
+      res.render('profileTestImg', {
         userData: user,
         likeQuestionData: likeQuestion,
         likeAnswerData: likeAnswer,
@@ -130,6 +130,22 @@ exports.patchUser = async (req, res) => {
     const userData = { uId: uId };
     let { email, pw, uName } = req.body;
     console.log(req.body);
+
+    const uNameIsDuplicate = await User.count({ where: { uName } });
+
+    if (uNameIsDuplicate) {
+      return res.status(409).json({
+        OK: false,
+        uNameIsDuplicate,
+        msg: '닉네임이 이미 존재합니다.',
+      });
+    }
+    if (!pw) {
+      return res.status(400).json({
+        OK: false,
+        msg: '입력 필드 중 하나 이상이 누락되었습니다.',
+      });
+    }
 
     pw = hashPassword(pw);
 

--- a/routes/usersRouter.js
+++ b/routes/usersRouter.js
@@ -20,6 +20,10 @@ router.post('/', Cuser.postUser);
 // /users/editprofile
 router.patch('/editprofile', needToLogin, Cprofile.patchUser);
 
+// 회원 탈퇴 시 비밀번호 확인
+// /users/checkpassword
+router.post('/checkpassword', Cprofile.checkPassword);
+
 // 회원 탈퇴 처리
 // /users/deleteprofile
 router.delete('/deleteprofile', needToLogin, Cprofile.deleteUser);

--- a/views/editprofile.ejs
+++ b/views/editprofile.ejs
@@ -66,7 +66,7 @@
 
     <button type="button" class="profileEdit" onclick="profileEdit();" disabled>수정하기</button><br>
 
-      <button type="button" class="profileDelete" onclick="profileDelete();">회원탈퇴</button>
+      <button type="button" class="profileDelete" onclick="openDeleteModal();">회원탈퇴</button>
     </form>
 
     <!-- Modal -->
@@ -84,6 +84,34 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">닫기</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 회원 탈퇴 확인용 모달 -->
+    <div class="modal fade" id="confirmDeleteModal" tabindex="-1" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="confirmDeleteModalLabel">회원 탈퇴</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>회원 탈퇴를 진행하려면 비밀번호를 입력하세요:</p>
+            <input id="deletePassword" type="password" class="form-control" placeholder="비밀번호">
+          </div>
+          <br>
+
+          <div id="pwModalMessage" class="alert alert-danger" style="display: none;"></div>
+          <br>
+
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">취소</button>
+            <button type="button" class="btn btn-danger" id="deletebtn" onclick="confirmDelete()">탈퇴</button>
           </div>
         </div>
       </div>
@@ -179,7 +207,7 @@
         // 초기화
         validateForm();
  
-   function profileEdit() {
+      function profileEdit() {
       const form_profile = document.forms['form_profile'];
             
       
@@ -220,24 +248,63 @@
       }
 
 
-      function profileDelete() {
-        if (confirm("정말 삭제 하시겠습니까?")) {
-          axios({
-            method: 'DELETE',
-            url: '/users/deleteprofile',
-          })
-          .then((result) => {
-            alert("삭제되었습니다.");
-            // 메인 화면으로 이동
-            document.location.href = '/';
-            resetFormInputs();
+      // 회원 탈퇴 확인용 모달 열기
+      function openDeleteModal() {
+        $('#confirmDeleteModal').modal('show');
+      }
 
+      // 회원 탈퇴 확인
+      function confirmDelete() {
+        const deletePassword = document.getElementById('deletePassword').value;
+
+        // 비밀번호 서버 전송
+        axios({
+          method: 'POST',
+          url: '/users/checkpassword',
+          data: {
+            password: deletePassword,
+          },
+        })
+          .then((result) => {
+            // 비번 체크하고 맞으면
+            if (result.data.success) {
+              // 사용자 정보 삭제 요청 전송
+              axios({
+                method: 'DELETE',
+                url: '/users/deleteprofile',
+              })
+                .then((deleteResult) => {
+                  alert('회원 탈퇴가 완료되었습니다.');
+                  document.location.href = '/';
+                })
+                .catch((deleteError) => {
+                  console.error(deleteError);
+                });
+            } else {
+              // 비밀번호 불일치
+              const errorMessage = '비밀번호가 일치하지 않습니다. 다시 시도해주세요.';
+              const errorMessageElement = document.getElementById('pwModalMessage');
+              errorMessageElement.textContent = errorMessage;
+              errorMessageElement.style.display = 'block';
+              $('#deletePassword').val(''); // 비밀번호 입력창 초기화
+            }
           })
-          .catch((err) => {
-            console.log(err);
+          .catch((error) => {
+            console.error(error);
+            const status = error.response.request.status;
+            if (status === 401) {
+              const errorMessage = '비밀번호가 일치하지 않습니다. 다시 시도해주세요.';
+              const errorMessageElement = document.getElementById('pwModalMessage');
+              errorMessageElement.textContent = errorMessage;
+              errorMessageElement.style.display = 'block';
+              $('#deletePassword').val(''); // 비밀번호 입력창 초기화
+            } else {
+              alert('서버 오류 발생')
+              window.document.href = '/'
+            }
           });
-        }
-      } 
+      }
+
 
       // 모달창
       function setModalTextAndShow(message) {

--- a/views/editprofile.ejs
+++ b/views/editprofile.ejs
@@ -20,7 +20,7 @@
     <header>
       <img src="../../static/img/제목을 입력해주세요_-001 (2).png" ></img>
       <div>
-    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 20 20" class="bi-arrow-left" onclick="goToLogin()">
+    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 20 20" class="bi-arrow-left" onclick="goBack()">
       <circle cx="10" cy="10" r="9.5" fill="transparent" class="hover-circle" />
       <path fill="black" fill-rule="evenodd" transform="translate(2, 2)" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
     </svg>
@@ -215,7 +215,6 @@
               setModalTextAndShow('이미 사용중인 닉네임입니다.');
             } else {
               setModalTextAndShow('회원가입 중 오류가 발생했습니다.');
-              window.document.href = '/'
             }
         });
       }
@@ -253,6 +252,10 @@
         form_profile.email.value = '';
         form_profile.pw.value = '';
         form_profile.pw_check.value = '';
+      }
+      //뒤로가기 버튼 클릭시 사용자가 전에 머물던 페이지로 이동
+      function goBack() {
+        window.history.back();
       }
        
       

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -64,14 +64,15 @@
     <div id="nameErrorMessage" class="alert alert-danger" style="display: none;"></div>
     <div id="nameDuplicateMessage" class="alert alert-info" style="display: none;"></div>
     <div class="input-group mb-3">
-      <input type="text" class="form-control" name="email" id="email" aria-describedby="basic-addon2" 
+      <input type="text" class="form-control" name="emailVisible" id="emailVisible" aria-describedby="basic-addon2" 
         pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}" 
         title="올바른 이메일 형식을 입력해주세요." required oninput="checkEmailFormat()">
-      <span class="input-group-text" id="basic-addon2">@example.com</span>
-      <!-- <select class="form-select" id="emailDropdown" name="emailDropdown" onchange="updateEmail()">
+        <input type="hidden" id="email" name="email" aria-describedby="basic-addon2" required>
+      <!-- <span class="input-group-text" id="basic-addon2">@example.com</span> -->
+      <select class="form-select" id="emailDropdown" name="emailDropdown" onchange="checkEmailFormat()">
         <option value="" selected>직접 입력</option>
         <option value="@naver.com">@naver.com</option>
-        <option value="">@gmail.com</option> -->
+        <option value="">@gmail.com</option>
       </select>
     </div>
     <div id="emailErrorMessage" class="alert alert-danger" style="display: none;"></div>
@@ -168,7 +169,7 @@
       form_register.pw.addEventListener("input", checkFormValidity);
       form_register.pwCheck.addEventListener("input", checkFormValidity);
       form_register.uName.addEventListener("input", checkFormValidity);
-      form_register.email.addEventListener("input", checkFormValidity);
+      form_register.emailVisible.addEventListener("input", checkFormValidity);
       
       // 새싹 크루 -> 아니오
       function onNoSelected() {
@@ -253,21 +254,54 @@
 
           }
       }
-      // 이메일 필드 포커스가 벗어났을 때 
-      function checkEmailFormat() {
-          const emailInput = document.getElementById("email");
+
+      function isValidEmail(email) {
+        const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+        return emailRegex.test(email);
+      }
+
+      // 이메일 유효성 검사 함수
+        function checkEmailFormat() {
+          const emailInputVisible = document.getElementById("emailVisible");
+          const emailInputHidden = document.getElementById("email");
+          const emailDropdown = document.getElementById("emailDropdown");
           const emailErrorMessage = document.getElementById("emailErrorMessage");
 
-          if (!emailInput.validity.valid) {
-              // 형식이 올바르지 않은 경우 알림을 표시
-              const errorMessage = "올바른 이메일 형식을 입력해주세요.";
-              emailErrorMessage.textContent = errorMessage;
+          const selectedDomain = emailDropdown.value;
+          const emailPrefix = emailInputVisible.value.split('@')[0];
+
+          if (selectedDomain === "") {
+            // 직접 입력된 경우
+            if (!isValidEmail(emailInputVisible.value)) {
+              // 이메일 주소가 유효하지 않은 경우 알림을 표시
+              emailErrorMessage.textContent = "올바른 이메일 형식을 입력해주세요.";
               emailErrorMessage.style.display = "block";
-          } else {
-              // 형식이 올바른 경우 알림을 숨김
+            } else {
               emailErrorMessage.style.display = "none";
+              // 직접 입력인 경우 hidden 필드에도 동일한 값을 설정
+              emailInputHidden.value = emailInputVisible.value;
+            }
+          } else {
+            // 도메인 선택된 경우
+            const fullEmail = emailPrefix + selectedDomain;
+            if (!isValidEmail(fullEmail)) {
+              emailErrorMessage.textContent = "올바른 이메일 형식을 입력해주세요.";
+              emailErrorMessage.style.display = "block";
+            } else {
+              emailErrorMessage.style.display = "none";
+              // 선택한 도메인 값과 조합하여 hidden 필드에 설정
+              emailInputHidden.value = emailPrefix + selectedDomain;
+            }
           }
-      }
+        }
+
+
+
+      // 이메일 입력 필드의 입력 이벤트 리스너 등록
+      const emailInputVisible = document.getElementById("emailVisible");
+      const emailInputHidden = document.getElementById("email");
+      emailInputVisible.addEventListener("input", checkEmailFormat);
+      emailInputHidden.addEventListener("input", checkEmailFormat);
 
       // 비밀번호 일치 여부
       const pwInput = document.getElementById("pw");
@@ -338,6 +372,11 @@
 
         ssacCampus.textContent = '';
       }
+      
+
+
+      
+      
       // 회원가입 요청
       function register() {
           const form_register = document.forms['form_register'];
@@ -373,6 +412,7 @@
             .catch((error) => {
               const status = error.response.request.status;
               if (status === 400) {
+                console.log(error)
                 setModalTextAndShow('입력 필드 중 하나 이상이 누락되었습니다.');
               } else if (status === 409) {
                 setModalTextAndShow('아이디 또는 닉네임이 이미 존재합니다.');

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -72,7 +72,11 @@
       <select class="form-select" id="emailDropdown" name="emailDropdown" onchange="checkEmailFormat()">
         <option value="" selected>직접 입력</option>
         <option value="@naver.com">@naver.com</option>
-        <option value="">@gmail.com</option>
+        <option value="@gmail.com">@gmail.com</option>
+        <option value="@daum.net">@daum.net</option>
+        <option value="@kakao.com">@kakao.com</option>
+        <option value="@tistory.com">@tistory.com</option>
+        
       </select>
     </div>
     <div id="emailErrorMessage" class="alert alert-danger" style="display: none;"></div>

--- a/views/styles/editProfile.css
+++ b/views/styles/editProfile.css
@@ -87,6 +87,20 @@ h2 {
   margin-top: 1.5rem;
 }
 
+/* modal */
+.modal-content {
+  font-weight: bold;
+}
+
+#deletebtn {
+  background-color: #dc7983;
+  border-color: #dc7983;
+}
+#deletebtn:hover {
+  background-color: #c82333;
+  border-color: #c82333;
+}
+
 /* alert */
 .alert {
   position: relative;


### PR DESCRIPTION
<변경 사항>
1. 회원가입창
- 회원 가입 창에서 이메일 로직 수정 (직접입력, 도메인 선택에 따라 유효성 검사 진행 및 db 저장)
2. 회원정보수정
- 뒤로가기 버튼 수정
- 닉네임 중복 검사 -> 컨트롤러에 중복 검사 함수 추가 및 결과 받아와서 모달로 띄워주는 식
3. 회원 탈퇴
- 창 띄워서 비번맞으면 탈퇴 
